### PR TITLE
Fix MPI file writing

### DIFF
--- a/util/src/graph_stats.cpp
+++ b/util/src/graph_stats.cpp
@@ -32,6 +32,11 @@
 #include "Util.h"
 #include "GraphException.h"
 
+#ifdef MPI_VERSION
+#include <mpi.h>
+#warning building with science!
+#endif
+
 #if !WIN32 && !CYGWIN
   #include "orbconfig.h"
   #include "orbtimer.h"
@@ -325,6 +330,12 @@ void run_all_methods(Graph::Graph *g, ofstream &outfile, ofstream &timing_file, 
         gp.eigen_spectrum(g, eigen_spectrum, spectrum_spread);
         ORB_read(t2);
         print_time(timing_file, "Time(eigen spectrum)",t1,t2);
+
+#ifdef MPI_VERSION
+        int myrank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+        if(myrank == 0) {
+#endif
         outfile << "eigen_spectrum ";
         if(eigen_spectrum.size() > 0) {
           outfile << eigen_spectrum[0];
@@ -333,6 +344,9 @@ void run_all_methods(Graph::Graph *g, ofstream &outfile, ofstream &timing_file, 
           outfile << ", " << eigen_spectrum[idx];
         }
         outfile << "\n";
+#ifdef MPI_VERSION
+        }
+#endif
     }
     #endif // ifdef HAS_PETSC
 
@@ -437,6 +451,13 @@ int main(int argc, char **argv){
     Graph::GraphProperties gp;
     Graph::GraphUtil gu;
 
+#ifdef MPI_VERSION
+    MPI_Init(&argc, &argv);
+    int myrank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+    if(myrank==0) {
+#endif
+
     // Set up output streams
     if(file_append == false){
         outfile.open(outfilename.c_str());
@@ -448,6 +469,10 @@ int main(int argc, char **argv){
         cerr << "Error opening " << outfilename << " for writing, exiting" << endl;
         exit(1);
     }
+
+#ifdef MPI_VERSION
+    }
+#endif
 
     // Read in the graph and start recording things to output streams
     cout << "Reading graph" << endl;
@@ -551,6 +576,10 @@ int main(int argc, char **argv){
         outfile.close();
         timing_file.close();
     }
+
+#ifdef MPI_VERSION
+    MPI_Finalize();
+#endif
 
     exit(0);
 } // main


### PR DESCRIPTION
When writing out to the output file the old MPI version would open the file multiple times and write out the result multiple times. Now only rank 0 writes.
